### PR TITLE
Show the field label for text fields

### DIFF
--- a/client/views/signUp/extraSignUpFields.js
+++ b/client/views/signUp/extraSignUpFields.js
@@ -32,7 +32,7 @@ Template._entryExtraSignUpField.helpers({
     if (this.required) {
       req = " required";
     }
-    var str =  "<label for='"+ this.field +"'>" + this.field + "</label><input type='"+ this.type +"' id='" + this.field + "' name='"+ this.field +"' value='"+ this.name +"' class='form-control "+ this.html_class +"' placeholder='" + this.placeholder +"'" + req +">";
+    var str =  "<label for='"+ this.field +"'>" + this.label + "</label><input type='"+ this.type +"' id='" + this.field + "' name='"+ this.field +"' value='"+ this.name +"' class='form-control "+ this.html_class +"' placeholder='" + this.placeholder +"'" + req +">";
 
     return new Spacebars.SafeString(str); 
   },


### PR DESCRIPTION
At present the field name is always shown for text fields, even when the label is set in AccountsEntry.config()
